### PR TITLE
0.2.5

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,8 +1,11 @@
 REM Install the latest dotnet-core and SDK using dotnet-install scripts.
 mkdir %BUILD_PREFIX% 2> NUL
+if exist %BUILD_PREFIX%\dotnet ( rmdir %BUILD_PREFIX%\dotnet /s /q )
 curl -L -o %BUILD_PREFIX%\dotnet-install.ps1 https://dot.net/v1/dotnet-install.ps1
 powershell %BUILD_PREFIX%\dotnet-install.ps1 -InstallDir %BUILD_PREFIX%\dotnet -Version latest
 set PATH=%BUILD_PREFIX%\dotnet;%PATH%
 
 REM Now install the package
 %PYTHON% -m pip install . --no-deps -vv
+REM Remember to shutdown the build server so that future builds aren't affected.
+dotnet build-server shutdown

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,4 +5,4 @@ powershell %BUILD_PREFIX%\dotnet-install.ps1 -InstallDir %BUILD_PREFIX%\dotnet -
 set PATH=%BUILD_PREFIX%\dotnet;%PATH%
 
 REM Now install the package
-%PYTHON% -m pip install . -vv
+%PYTHON% -m pip install . --no-deps -vv

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,8 @@
+REM Install the latest dotnet-core and SDK using dotnet-install scripts.
+mkdir %BUILD_PREFIX% 2> NUL
+curl -L -o %BUILD_PREFIX%\dotnet-install.ps1 https://dot.net/v1/dotnet-install.ps1
+powershell %BUILD_PREFIX%\dotnet-install.ps1 -InstallDir %BUILD_PREFIX%\dotnet -Version latest
+set PATH=%BUILD_PREFIX%\dotnet;%PATH%
+
+REM Now install the package
+%PYTHON% -m pip install . -vv

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,4 +5,4 @@ source $BUILD_PREFIX/dotnet-install.sh --install-dir $BUILD_PREFIX/dotnet --vers
 export PATH="$BUILD_PREFIX/dotnet:$PATH"
 
 # Now install the package.
-$PYTHON -m pip install . -vv
+$PYTHON -m pip install . --no-deps -vv

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,8 +1,8 @@
 # Install the latest dotnet-core and SDK using dotnet-install scripts.
 mkdir -p $BUILD_PREFIX
 curl -L -o $BUILD_PREFIX/dotnet-install.sh https://dot.net/v1/dotnet-install.sh && chmod +x $BUILD_PREFIX/dotnet-install.sh
-./$BUILD_PREFIX/dotnet-install.sh -install_dir $BUILD_PREFIX/dotnet -version latest
-export PATH=$BUILD_PREFIX/dotnet;$PATH
+source $BUILD_PREFIX/dotnet-install.sh --install-dir $BUILD_PREFIX/dotnet --version latest
+export PATH="$BUILD_PREFIX/dotnet:$PATH"
 
 # Now install the package.
 $PYTHON -m pip install . -vv

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,0 +1,8 @@
+# Install the latest dotnet-core and SDK using dotnet-install scripts.
+mkdir -p $BUILD_PREFIX
+curl -L -o $BUILD_PREFIX/dotnet-install.sh https://dot.net/v1/dotnet-install.sh && chmod +x $BUILD_PREFIX/dotnet-install.sh
+./$BUILD_PREFIX/dotnet-install.sh -install_dir $BUILD_PREFIX/dotnet -version latest
+export PATH=$BUILD_PREFIX/dotnet;$PATH
+
+# Now install the package.
+$PYTHON -m pip install . -vv

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,6 +3,7 @@ mkdir -p $BUILD_PREFIX
 curl -L -o $BUILD_PREFIX/dotnet-install.sh https://dot.net/v1/dotnet-install.sh && chmod +x $BUILD_PREFIX/dotnet-install.sh
 source $BUILD_PREFIX/dotnet-install.sh --install-dir $BUILD_PREFIX/dotnet --version latest
 export PATH="$BUILD_PREFIX/dotnet:$PATH"
+export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
 
 # Now install the package.
 $PYTHON -m pip install . --no-deps -vv

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,8 +1,0 @@
-cudnn:                                            # [linux64]
-  - undefined                                     # [linux64]
-cuda_compiler_version:                            # [linux64]
-  - None                                          # [linux64]
-docker_image:                                     # [linux64]
-  - quay.io/condaforge/linux-anvil-cos7-x86_64    # [linux64]
-cdt_name:                                         # [linux64]
-  - cos7                                          # [linux64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - setuptools
     - setuptools-scm
     - wheel
+    - icu    # [linux]
   run:
     - cffi >=1.13
     - python
@@ -48,3 +49,4 @@ about:
 extra:
   recipe-maintainers:
     - m-rossi
+    - sumit0190

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - python
     - pip
     - setuptools
-    - setuptools-scm
+    - setuptools_scm
     - wheel
   run:
     - cffi >=1.13

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - setuptools
     - setuptools_scm
     - wheel
+    - toml
   run:
     - cffi >=1.13
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,8 @@ source:
 
 build:
   number: 0
-  # We skip for PPC64 since the dotnet binaries for this architecture aren't available.
-  skip: True # [ppc64le]
+  # We skip for PPC64 and s390x since the dotnet binaries for this architecture aren't available.
+  skip: True # [ppc64le or s390x]
   skip: True # [py<37]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,21 +13,20 @@ build:
   number: 0
   # We skip for PPC64 since the dotnet binaries for this architecture aren't available.
   skip: True # [ppc64le]
+  skip: True # [py<37]
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - pip
-    - setuptools >=61
+    - setuptools
     - setuptools-scm
     - wheel
   run:
     - cffi >=1.13
-    - python >=3.7
+    - python
 
 test:
-  imports:
-    - clr_loader
   requires:
     - pip
     - importlib_resources
@@ -40,6 +39,9 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: Generic pure Python loader for .NET runtimes
+  description: |
+    Implements a generic interface for loading one of the CLR (.NET) runtime
+    implementations and calling simple functions on them.
   dev_url: https://github.com/pythonnet/clr-loader
   doc_url: https://pythonnet.github.io/clr-loader/
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "clr_loader" %}
-{% set version = "0.2.4" %}
+{% set version = "0.2.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,16 +7,14 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 7b4516e363b3054b46e93a3d39cb1968e58d6eeccea0e8c0bc86f1100a2f4cc5
+  sha256: 82ed5fb654729d14fd88296e74bb6b84eb2cfb976ff4b7d49d4e449fd78a226b
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  # We skip for PPC64 since the dotnet binaries for this architecture aren't available.
+  skip: True # [ppc64le]
 
 requirements:
-  build:
-    - dotnet-sdk >=6
   host:
     - python >=3.7
     - pip
@@ -32,9 +30,7 @@ test:
     - clr_loader
   requires:
     - pip
-    - dotnet-runtime 6.0
     - importlib_resources
-    - mono
   commands:
     - pip check
 
@@ -45,6 +41,7 @@ about:
   license_file: LICENSE
   summary: Generic pure Python loader for .NET runtimes
   dev_url: https://github.com/pythonnet/clr-loader
+  doc_url: https://pythonnet.github.io/clr-loader/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,6 @@ requirements:
     - setuptools
     - setuptools-scm
     - wheel
-    - icu    # [linux]
   run:
     - cffi >=1.13
     - python

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -13,10 +13,4 @@ for arch in ['amd64', 'x86']:
     for ext in ['dll', 'pdb']:
         if not (base_path / arch / f'ClrLoader.{ext}').exists():
             raise FileNotFoundError(f'DLL ffi/dlls/{arch}/ClrLoader.{ext} not found in package.')
-
-# Try to get different runtimes
-if sys.platform == 'win32':
-    clr_loader.get_netfx()
-if sys.platform != 'win32':
-    clr_loader.get_mono()
-clr_loader.get_coreclr()
+print("DLLs found; test passed.")


### PR DESCRIPTION
This is required by Microsoft, and also indirectly as a dependency of `pythonnet`. This feedstock was included in `aggregate` a while ago but I guess no one could get it to build.
Note: `s390x` and `ppc64le` are skipped because their `dotnet` builds aren't available (well, `s390x` is but for some reason they aren't stable).