### PR TITLE
Update recipe for py313_codesign

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -6,6 +6,6 @@ powershell %BUILD_PREFIX%\dotnet-install.ps1 -InstallDir %BUILD_PREFIX%\dotnet -
 set PATH=%BUILD_PREFIX%\dotnet;%PATH%
 
 REM Now install the package
-%PYTHON% -m pip install . --no-deps -vv
+%PYTHON% -m pip install . --no-deps --no-build-isolation -vv
 REM Remember to shutdown the build server so that future builds aren't affected.
 dotnet build-server shutdown

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,9 +1,10 @@
-# Install the latest dotnet-core and SDK using dotnet-install scripts.
+# Install dotnet-core 7 and SDK using dotnet-install scripts. - dotnet 8 requires a more recent glibc
+# https://github.com/dotnet/core/blob/main/release-notes/7.0/supported-os.md
 mkdir -p $BUILD_PREFIX
 curl -L -o $BUILD_PREFIX/dotnet-install.sh https://dot.net/v1/dotnet-install.sh && chmod +x $BUILD_PREFIX/dotnet-install.sh
-source $BUILD_PREFIX/dotnet-install.sh --install-dir $BUILD_PREFIX/dotnet --version latest
+source $BUILD_PREFIX/dotnet-install.sh --install-dir $BUILD_PREFIX/dotnet --version 7.0.109
 export PATH="$BUILD_PREFIX/dotnet:$PATH"
 export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
 
 # Now install the package.
-$PYTHON -m pip install . --no-deps -vv
+$PYTHON -m pip install . --no-deps --no-build-isolation -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,8 @@ requirements:
     - wheel
     - toml
   run:
-    - cffi >=1.13
+    - cffi >=1.13  # [py<38]
+    - cffi >=1.17  # [py>=38]
     - python
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "clr_loader" %}
-{% set version = "0.2.5" %}
+{% set version = "0.2.7.post0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 82ed5fb654729d14fd88296e74bb6b84eb2cfb976ff4b7d49d4e449fd78a226b
+  sha256: b7a8b3f8fbb1bcbbb6382d887e21d1742d4f10b5ea209e4ad95568fe97e1c7c6
 
 build:
-  number: 1
+  number: 0
   # We skip for PPC64 and s390x since the dotnet binaries for this architecture aren't available.
   skip: True # [ppc64le or s390x]
   skip: True # [py<37]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 82ed5fb654729d14fd88296e74bb6b84eb2cfb976ff4b7d49d4e449fd78a226b
 
 build:
-  number: 0
+  number: 1
   # We skip for PPC64 and s390x since the dotnet binaries for this architecture aren't available.
   skip: True # [ppc64le or s390x]
   skip: True # [py<37]


### PR DESCRIPTION
Rebuild for codesigned win-64 py313 artifacts.

Update to 0.2.7 
https://github.com/pythonnet/clr-loader/tree/v0.2.7-0

.net sdk downloaded for the same reasons as stated in https://github.com/AnacondaRecipes/clr_loader-feedstock/pull/3
